### PR TITLE
Fix erroneous references to env-setup to actually link to appendix

### DIFF
--- a/manuscript/appendix01.md
+++ b/manuscript/appendix01.md
@@ -1,4 +1,4 @@
-# Environment setup {#env-setup}
+# Environment setup
 
 ## Prerequisite: a modern browser
 

--- a/manuscript/chapter12.md
+++ b/manuscript/chapter12.md
@@ -135,7 +135,7 @@ A JavaScript file, usually stored in a `.js` file, is loaded by a web page with 
 
 To create interactive web pages, you need to write HTML, CSS and JavaScript code. If you're just starting out, the easiest way to do so is by using an online JavaScript playground. However, you will likely want to develop in a more professional fashion at some point, or need to work offline.
 
-Refer to the [appendix](#env-setup) for details on setting up your environment.
+Refer to the [appendix](appendix01.md) for details on setting up your environment.
 
 ## Coding time!
 

--- a/manuscript/chapter24.md
+++ b/manuscript/chapter24.md
@@ -40,7 +40,7 @@ Node also made it easier for developers to publish, share and reuse code. Today,
 
 ### A first example
 
-> The rest of this chapter assumes a working Node environnement. Refer to the [appendix](#env-setup) for setting one up.
+> The rest of this chapter assumes a working Node environnement. Refer to the [appendix](appendix01.md) for setting one up.
 
 The simplest possible Node program is as follows.
 

--- a/manuscript/intro01.md
+++ b/manuscript/intro01.md
@@ -23,7 +23,7 @@ You have two options for following along, depending on how eager you are to get 
 * Coding online, using feature-packed JavaScript playgrounds like [CodePen](https://codepen.io) and [Glitch](https://glitch.com).
 * Building a local development environment.
 
-First option is the easiest and quickest; Second one is more powerful and will probably become necessary as you tackle bigger programming challenges in a not-so-distant future. Refer to the [appendix](#env-setup) for details on both.
+First option is the easiest and quickest; Second one is more powerful and will probably become necessary as you tackle bigger programming challenges in a not-so-distant future. Refer to the [appendix](appendix01.md) for details on both.
 
 Whichever solution you may choose, be sure to test *every* code sample and search *every* exercise and project. Reading along is not enough: coding along is mandatory to get a real grasp of how things work and become a capable programmer.
 


### PR DESCRIPTION
Previously linking to nowhere, now these links actually point to the appendix referenced. Resolves #28 

This seems to be an issue of learnpub and github not playing well together.