### PR TITLE
Update ch8 - 2 call examples for startsWith and endsWith

### DIFF
--- a/manuscript/chapter08.md
+++ b/manuscript/chapter08.md
@@ -183,10 +183,12 @@ When searching for a value at the beginning or end of a string, you may also use
 const song = "Honky Tonk Women";
 
 console.log(song.startsWith("Honk")); // true
+console.log(song.startsWith("honk")); // false
 console.log(song.startsWith("Tonk")); // false
 
 console.log(song.endsWith("men")); // true
 console.log(song.endsWith("Men")); // false
+console.log(song.endsWith("Tonk")); // false
 ```
 
 ## Breaking a string into parts


### PR DESCRIPTION
Provide two call examples returning false when calling the two methods
startsWith and endsWith : one when the searched string is in the middle of
the string, and one when the searched string is at the beginning or at the
end of the string but with case mismatch.